### PR TITLE
build Wiretrustee management binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,7 @@
 project_name: wiretrustee
 builds:
-  - env: [CGO_ENABLED=0]
+  - id: wiretrustee
+    env: [CGO_ENABLED=0]
 
     goos:
       - linux
@@ -19,10 +20,25 @@ builds:
         goarch: arm
     tags:
       - load_wintun_from_rsrc
+      -
+  - id: wiretrustee-mgmt
+    dir: management
+    env: [CGO_ENABLED=0]
+
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+archives:
+  - builds:
+      - wiretrustee
 nfpms:
   - maintainer: Wiretrustee <wiretrustee@wiretrustee.com>
     description: Wiretrustee project.
     homepage: https://wiretrustee.com/
+    builds:
+      - wiretrustee
     formats:
       - deb
       - rpm
@@ -39,6 +55,8 @@ nfpms:
 dockers:
   - image_templates:
       - wiretrustee/wiretrustee:signal-{{ .Version }}-amd64
+    ids:
+      - wiretrustee
     goarch: amd64
     use: buildx
     dockerfile: signal/Dockerfile
@@ -52,6 +70,8 @@ dockers:
       - "--label=maintainer=wiretrustee@wiretrustee.com"
   - image_templates:
       - wiretrustee/wiretrustee:signal-{{ .Version }}-arm64v8
+    ids:
+      - wiretrustee
     goarch: arm64
     use: buildx
     dockerfile: signal/Dockerfile
@@ -65,6 +85,8 @@ dockers:
       - "--label=maintainer=wiretrustee@wiretrustee.com"
   - image_templates:
       - wiretrustee/wiretrustee:management-{{ .Version }}-amd64
+    ids:
+      - wiretrustee-mgmt
     goarch: amd64
     use: buildx
     dockerfile: management/Dockerfile
@@ -78,6 +100,8 @@ dockers:
       - "--label=maintainer=wiretrustee@wiretrustee.com"
   - image_templates:
       - wiretrustee/wiretrustee:management-{{ .Version }}-arm64v8
+    ids:
+      - wiretrustee-mgmt
     goarch: arm64
     use: buildx
     dockerfile: management/Dockerfile


### PR DESCRIPTION
Builds management binaries, but don't archive them as tars, only as docker images