### PR TITLE
increase key used times after successful peer registration

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -277,6 +277,7 @@ func (manager *AccountManager) AddPeer(setupKey string, peerKey string) (*Peer, 
 	}
 
 	account.Peers[newPeer.Key] = newPeer
+	account.SetupKeys[sk.Key] = sk.IncrementUsage()
 	err = manager.Store.SaveAccount(account)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed adding peer")

--- a/management/server/http/handler/setupkeys.go
+++ b/management/server/http/handler/setupkeys.go
@@ -18,13 +18,15 @@ type SetupKeys struct {
 
 // SetupKeyResponse is a response sent to the client
 type SetupKeyResponse struct {
-	Id      string
-	Key     string
-	Name    string
-	Expires time.Time
-	Type    server.SetupKeyType
-	Valid   bool
-	Revoked bool
+	Id        string
+	Key       string
+	Name      string
+	Expires   time.Time
+	Type      server.SetupKeyType
+	Valid     bool
+	Revoked   bool
+	UsedTimes int
+	LastUsed  time.Time
 }
 
 // SetupKeyRequest is a request sent by client. This object contains fields that can be modified
@@ -47,6 +49,11 @@ func (h *SetupKeys) CreateKey(w http.ResponseWriter, r *http.Request) {
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if !(req.Type == server.SetupKeyReusable || req.Type == server.SetupKeyOneOff) {
+		http.Error(w, "unknown setup key type "+string(req.Type), http.StatusBadRequest)
 		return
 	}
 
@@ -166,12 +173,14 @@ func writeSuccess(w http.ResponseWriter, key *server.SetupKey) {
 
 func toResponseBody(key *server.SetupKey) *SetupKeyResponse {
 	return &SetupKeyResponse{
-		Id:      key.Id,
-		Key:     key.Key,
-		Name:    key.Name,
-		Expires: key.ExpiresAt,
-		Type:    key.Type,
-		Valid:   key.IsValid(),
-		Revoked: key.Revoked,
+		Id:        key.Id,
+		Key:       key.Key,
+		Name:      key.Name,
+		Expires:   key.ExpiresAt,
+		Type:      key.Type,
+		Valid:     key.IsValid(),
+		Revoked:   key.Revoked,
+		UsedTimes: key.UsedTimes,
+		LastUsed:  key.LastUsed,
 	}
 }

--- a/management/server/setupkey.go
+++ b/management/server/setupkey.go
@@ -35,6 +35,8 @@ type SetupKey struct {
 	Revoked bool
 	// UsedTimes indicates how many times the key was used
 	UsedTimes int
+	// LastUsed last time the key was used for peer registration
+	LastUsed time.Time
 }
 
 //Copy copies SetupKey to a new object
@@ -49,6 +51,14 @@ func (key *SetupKey) Copy() *SetupKey {
 		Revoked:   key.Revoked,
 		UsedTimes: key.UsedTimes,
 	}
+}
+
+//IncrementUsage makes a copy of a key, increments the UsedTimes by 1 and sets LastUsed to now
+func (key *SetupKey) IncrementUsage() *SetupKey {
+	c := key.Copy()
+	c.UsedTimes = c.UsedTimes + 1
+	c.LastUsed = time.Now()
+	return c
 }
 
 // IsValid is true if the key was not revoked, is not expired and used not more than it was supposed to


### PR DESCRIPTION
- [x] when setup key is used for peer registration then the UsedTimes property of a key should be increased
- [x] add UsedTimes property to the HTTP response