### PR TITLE
Removed installer and add workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,28 +51,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
       -
-        id: get_version
-        uses: battila7/get-version-action@v2
-      -
-        name: Install makensis
-        run: sudo apt update && sudo apt install -y nsis nsis-pluginapi
-      -
-        name: Download EnvVar Plugin
-        run: curl -L -o EnVar_plugin.zip https://nsis.sourceforge.io/mediawiki/images/7/7f/EnVar_plugin.zip
-      -
-        name: Extract EnVar plugin
-        run: sudo 7z x -o"/usr/share/nsis/" EnVar_plugin.zip
-      -
-        name: Generate Windows installer
-        run:  makensis -V4 client/installer.nsis
-        env:
-          APPVER: ${{ steps.get_version.outputs.major }}.${{ steps.get_version.outputs.minor }}.${{ steps.get_version.outputs.patch }}.${{ github.run_id }}
-      -
-        name: Upload windows installer to release page
-        uses: svenstaro/upload-release-action@v2
+        name: Trigger Windows binaries sign pipeline
+        uses: benc-uk/workflow-dispatch@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: wiretrustee-installer.exe
-          asset_name: wiretrustee_installer_${{ steps.get_version.outputs.version-without-v }}_windows_amd64.exe
-          tag: ${{ github.ref }}
+          workflow: Sign windows bin and installer
+          repo: wiretrustee/windows-sign-pipeline
+          ref: v0.0.1
+          token: ${{ secrets.SIGN_GITHUB_TOKEN }}
+          inputs: '{ "tag": "${{ github.ref }}" }'


### PR DESCRIPTION
This change means that we will be building the binary files for windows, and a private repository action will be handling signing, installer generation and updating the release with the Signed versions of the client and its installer.

The reason for that is that we need a  Self-hosted runner with a Windows server in order to sign the packages using the certificate from Certum. This will allow us to safely run the signing workflow without disabling all incoming PRs.

We should consider in the near future a replacement for the certificate provider.