### PR TITLE
fix: too many open files caused by agent not being closed

### DIFF
--- a/client/internal/connection.go
+++ b/client/internal/connection.go
@@ -138,11 +138,17 @@ func (conn *Connection) Open(timeout time.Duration) error {
 			return !ok
 		},
 	})
-	conn.agent = a
-
 	if err != nil {
 		return err
 	}
+
+	conn.agent = a
+	defer func() {
+		err := conn.agent.Close()
+		if err != nil {
+			return
+		}
+	}()
 
 	err = conn.listenOnLocalCandidates()
 	if err != nil {

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -148,6 +148,11 @@ func (e *Engine) initializePeer(peer Peer) {
 	}, e.ctx)
 
 	operation := func() error {
+
+		if e.signal.GetStatus() != signal.StreamConnected {
+			return fmt.Errorf("not opening connection to peer because Signal is unavailable")
+		}
+
 		_, err := e.openPeerConnection(e.wgPort, e.config.WgPrivateKey, peer)
 		e.peerMux.Lock()
 		defer e.peerMux.Unlock()
@@ -157,7 +162,7 @@ func (e *Engine) initializePeer(peer Peer) {
 		}
 
 		if err != nil {
-			log.Infof("retrying connection because of error: %s", err.Error())
+			log.Debugf("retrying connection because of error: %s", err.Error())
 			return err
 		}
 		return nil

--- a/signal/client/client_test.go
+++ b/signal/client/client_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Client", func() {
 	})
 
 	Describe("Exchanging messages", func() {
-		Context("between streamConnected peers", func() {
+		Context("between connected peers", func() {
 			It("should be successful", func() {
 
 				var msgReceived sync.WaitGroup


### PR DESCRIPTION
Too many open files are caused by the agent not being closed after unsuccessful attempts to start a peer connection.

Open FDs are growing if clients can't connect to Signal. Happens due to numerous retries without closing agent on failure.