### PR TITLE
Rollback stopping management client within engine stop

### DIFF
--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -22,11 +22,13 @@ var (
 		Short: "install, login and start wiretrustee client",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			SetFlagsFromEnvVars()
+
 			err := loginCmd.RunE(cmd, args)
 			if err != nil {
 				return err
 			}
 			if logFile == "console" {
+				SetupCloseHandler()
 				return runClient()
 			}
 

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -96,13 +96,7 @@ func (e *Engine) Stop() error {
 	e.syncMsgMux.Lock()
 	defer e.syncMsgMux.Unlock()
 
-	err := e.mgmClient.Close()
-	if err != nil {
-		log.Errorf("failed closing engine's management client: %v", err)
-		return err
-	}
-
-	err = e.removeAllPeers()
+	err := e.removeAllPeers()
 	if err != nil {
 		return err
 	}

--- a/client/internal/engine_test.go
+++ b/client/internal/engine_test.go
@@ -351,7 +351,11 @@ func TestEngine_MultiplePeers(t *testing.T) {
 
 	// cleanup test
 	for _, peerEngine := range engines {
-		errStop := peerEngine.Stop()
+		errStop := peerEngine.mgmClient.Close()
+		if errStop != nil {
+			log.Infoln("got error trying to close management clients from engine: ", errStop)
+		}
+		errStop = peerEngine.Stop()
 		if errStop != nil {
 			log.Infoln("got error trying to close testing peers engine: ", errStop)
 		}


### PR DESCRIPTION
Rollback's previous change was causing issues with agent stop logic. 