### PR TITLE
Add client version to the client app and send it to the management service

### DIFF
--- a/client/system/info.go
+++ b/client/system/info.go
@@ -3,12 +3,13 @@ package system
 //Info is an object that contains machine information
 // Most of the code is taken from https://github.com/matishsiao/goInfo
 type Info struct {
-	GoOS      string
-	Kernel    string
-	Core      string
-	Platform  string
-	OS        string
-	OSVersion string
-	Hostname  string
-	CPUs      int
+	GoOS               string
+	Kernel             string
+	Core               string
+	Platform           string
+	OS                 string
+	OSVersion          string
+	Hostname           string
+	CPUs               int
+	WiretrusteeVersion string
 }

--- a/client/system/info_linux.go
+++ b/client/system/info_linux.go
@@ -45,6 +45,7 @@ func GetInfo() *Info {
 	gio := &Info{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osName, OSVersion: osVer, GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
 	gio.WiretrusteeVersion = _getWiretrusteeVersion()
+
 	return gio
 }
 
@@ -85,7 +86,7 @@ func _getWiretrusteeVersion() string {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		fmt.Println("getReleaseInfo:", err)
+		fmt.Println("getWiretrusteeInfo:", err)
 	}
 
 	return out.String()

--- a/client/system/info_linux.go
+++ b/client/system/info_linux.go
@@ -44,6 +44,7 @@ func GetInfo() *Info {
 	}
 	gio := &Info{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osName, OSVersion: osVer, GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
+	gio.WiretrusteeVersion = _getWiretrusteeVersion()
 	return gio
 }
 
@@ -72,5 +73,20 @@ func _getReleaseInfo() string {
 	if err != nil {
 		fmt.Println("getReleaseInfo:", err)
 	}
+	return out.String()
+}
+
+func _getWiretrusteeVersion() string {
+	cmd := exec.Command("wiretrustee", "version")
+	cmd.Stdin = strings.NewReader("some")
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("getReleaseInfo:", err)
+	}
+
 	return out.String()
 }

--- a/management/client/grpc.go
+++ b/management/client/grpc.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	log "github.com/sirupsen/logrus"
 	"github.com/wiretrustee/wiretrustee/client/system"
@@ -15,8 +18,6 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
-	"io"
-	"time"
 )
 
 type GrpcClient struct {
@@ -241,7 +242,7 @@ func (c *GrpcClient) Register(serverKey wgtypes.Key, setupKey string) (*proto.Lo
 		Core:               gi.OSVersion,
 		Platform:           gi.Platform,
 		Kernel:             gi.Kernel,
-		WiretrusteeVersion: "",
+		WiretrusteeVersion: gi.WiretrusteeVersion,
 	}
 	log.Debugf("detected system %v", meta)
 	return c.login(serverKey, &proto.LoginRequest{SetupKey: setupKey, Meta: meta})


### PR DESCRIPTION
What?
    * Add a property to the client installation to store the current version
    * Send client version to the Management Service on login request together with the machine info.

Why?
    * Network Administrator can keep track of the installed clients
    * Suggest updates to the latest versions to users