### PR TITLE
Add client version to the client app and send it to the management service

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,7 @@ builds:
       - goos: windows
         goarch: arm
     ldflags:
-      - -s -w -X github.com/wiretrustee/wiretrustee/client/system.Version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
+      - -s -w -X github.com/wiretrustee/wiretrustee/client/system.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
     mod_timestamp: '{{ .CommitTimestamp }}'
     tags:
       - load_wgnt_from_rsrc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,7 @@ builds:
       - goos: windows
         goarch: arm
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
+      - -s -w -X github.com/wiretrustee/wiretrustee/client/system.Version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
     mod_timestamp: '{{ .CommitTimestamp }}'
     tags:
       - load_wgnt_from_rsrc

--- a/client/cmd/version.go
+++ b/client/cmd/version.go
@@ -1,14 +1,16 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+	"github.com/wiretrustee/wiretrustee/client/system"
+)
 
 var (
-	Version    string
 	versionCmd = &cobra.Command{
 		Use:   "version",
 		Short: "prints wiretrustee version",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Println(Version)
+			cmd.Println(system.Version)
 		},
 	}
 )

--- a/client/cmd/version.go
+++ b/client/cmd/version.go
@@ -10,7 +10,7 @@ var (
 		Use:   "version",
 		Short: "prints wiretrustee version",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Println(system.Version)
+			cmd.Println(system.WiretrusteeVersion())
 		},
 	}
 )

--- a/client/main.go
+++ b/client/main.go
@@ -1,15 +1,12 @@
 package main
 
 import (
-	"github.com/wiretrustee/wiretrustee/client/cmd"
 	"os"
+
+	"github.com/wiretrustee/wiretrustee/client/cmd"
 )
 
-var version = "development"
-
 func main() {
-
-	cmd.Version = version
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/client/system/info.go
+++ b/client/system/info.go
@@ -1,14 +1,19 @@
 package system
 
+// this is the wiretrustee version
+// will be replaced with the release version when using goreleaser
+var Version string = "development"
+
 //Info is an object that contains machine information
 // Most of the code is taken from https://github.com/matishsiao/goInfo
 type Info struct {
-	GoOS      string
-	Kernel    string
-	Core      string
-	Platform  string
-	OS        string
-	OSVersion string
-	Hostname  string
-	CPUs      int
+	GoOS               string
+	Kernel             string
+	Core               string
+	Platform           string
+	OS                 string
+	OSVersion          string
+	Hostname           string
+	CPUs               int
+	WiretrusteeVersion string
 }

--- a/client/system/info.go
+++ b/client/system/info.go
@@ -17,3 +17,7 @@ type Info struct {
 	CPUs               int
 	WiretrusteeVersion string
 }
+
+func wiretrusteeVersion() string {
+	return Version
+}

--- a/client/system/info.go
+++ b/client/system/info.go
@@ -2,7 +2,7 @@ package system
 
 // this is the wiretrustee version
 // will be replaced with the release version when using goreleaser
-var Version string = "development"
+var version = "development"
 
 //Info is an object that contains machine information
 // Most of the code is taken from https://github.com/matishsiao/goInfo
@@ -18,6 +18,6 @@ type Info struct {
 	WiretrusteeVersion string
 }
 
-func wiretrusteeVersion() string {
-	return Version
+func WiretrusteeVersion() string {
+	return version
 }

--- a/client/system/info_darwin.go
+++ b/client/system/info_darwin.go
@@ -21,6 +21,7 @@ func GetInfo() *Info {
 	osInfo := strings.Split(osStr, " ")
 	gio := &Info{Kernel: osInfo[0], OSVersion: osInfo[1], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[0], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
+	gio.wiretrusteeVersion = wiretrusteeVersion()
 	return gio
 }
 

--- a/client/system/info_darwin.go
+++ b/client/system/info_darwin.go
@@ -21,7 +21,7 @@ func GetInfo() *Info {
 	osInfo := strings.Split(osStr, " ")
 	gio := &Info{Kernel: osInfo[0], OSVersion: osInfo[1], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[0], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
-	gio.WiretrusteeVersion = wiretrusteeVersion()
+	gio.WiretrusteeVersion = WiretrusteeVersion()
 	return gio
 }
 

--- a/client/system/info_darwin.go
+++ b/client/system/info_darwin.go
@@ -21,7 +21,7 @@ func GetInfo() *Info {
 	osInfo := strings.Split(osStr, " ")
 	gio := &Info{Kernel: osInfo[0], OSVersion: osInfo[1], Core: osInfo[1], Platform: osInfo[2], OS: osInfo[0], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
-	gio.wiretrusteeVersion = wiretrusteeVersion()
+	gio.WiretrusteeVersion = wiretrusteeVersion()
 	return gio
 }
 

--- a/client/system/info_freebsd.go
+++ b/client/system/info_freebsd.go
@@ -21,7 +21,7 @@ func GetInfo() *Info {
 	osInfo := strings.Split(osStr, " ")
 	gio := &Info{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
-	gio.WiretrusteeVersion = wiretrusteeVersion()
+	gio.WiretrusteeVersion = WiretrusteeVersion()
 	return gio
 }
 

--- a/client/system/info_freebsd.go
+++ b/client/system/info_freebsd.go
@@ -21,6 +21,7 @@ func GetInfo() *Info {
 	osInfo := strings.Split(osStr, " ")
 	gio := &Info{Kernel: osInfo[0], Core: osInfo[1], Platform: runtime.GOARCH, OS: osInfo[2], GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
+	gio.WiretrusteeVersion = wiretrusteeVersion()
 	return gio
 }
 

--- a/client/system/info_linux.go
+++ b/client/system/info_linux.go
@@ -44,7 +44,7 @@ func GetInfo() *Info {
 	}
 	gio := &Info{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osName, OSVersion: osVer, GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
-	gio.WiretrusteeVersion = wiretrusteeVersion()
+	gio.WiretrusteeVersion = WiretrusteeVersion()
 
 	return gio
 }

--- a/client/system/info_linux.go
+++ b/client/system/info_linux.go
@@ -44,6 +44,8 @@ func GetInfo() *Info {
 	}
 	gio := &Info{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osName, OSVersion: osVer, GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
+	gio.WiretrusteeVersion = Version
+
 	return gio
 }
 

--- a/client/system/info_linux.go
+++ b/client/system/info_linux.go
@@ -44,7 +44,7 @@ func GetInfo() *Info {
 	}
 	gio := &Info{Kernel: osInfo[0], Core: osInfo[1], Platform: osInfo[2], OS: osName, OSVersion: osVer, GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
-	gio.WiretrusteeVersion = Version
+	gio.WiretrusteeVersion = wiretrusteeVersion()
 
 	return gio
 }

--- a/client/system/info_test.go
+++ b/client/system/info_test.go
@@ -1,0 +1,13 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_LocalVersion(t *testing.T) {
+	got := GetInfo()
+	want := "development"
+	assert.Equal(t, want, got.WiretrusteeVersion)
+}

--- a/client/system/info_windows.go
+++ b/client/system/info_windows.go
@@ -31,7 +31,7 @@ func GetInfo() *Info {
 	}
 	gio := &Info{Kernel: "windows", OSVersion: ver, Core: ver, Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
-	gio.wiretrusteeVersion = wiretrusteeVersion()
+	gio.WiretrusteeVersion = wiretrusteeVersion()
 
 	return gio
 }

--- a/client/system/info_windows.go
+++ b/client/system/info_windows.go
@@ -31,5 +31,7 @@ func GetInfo() *Info {
 	}
 	gio := &Info{Kernel: "windows", OSVersion: ver, Core: ver, Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
+	gio.wiretrusteeVersion = wiretrusteeVersion()
+
 	return gio
 }

--- a/client/system/info_windows.go
+++ b/client/system/info_windows.go
@@ -31,7 +31,7 @@ func GetInfo() *Info {
 	}
 	gio := &Info{Kernel: "windows", OSVersion: ver, Core: ver, Platform: "unknown", OS: "windows", GoOS: runtime.GOOS, CPUs: runtime.NumCPU()}
 	gio.Hostname, _ = os.Hostname()
-	gio.WiretrusteeVersion = wiretrusteeVersion()
+	gio.WiretrusteeVersion = WiretrusteeVersion()
 
 	return gio
 }

--- a/management/client/grpc.go
+++ b/management/client/grpc.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	log "github.com/sirupsen/logrus"
 	"github.com/wiretrustee/wiretrustee/client/system"
@@ -15,8 +18,6 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
-	"io"
-	"time"
 )
 
 type GrpcClient struct {
@@ -241,7 +242,7 @@ func (c *GrpcClient) Register(serverKey wgtypes.Key, setupKey string) (*proto.Lo
 		Core:               gi.OSVersion,
 		Platform:           gi.Platform,
 		Kernel:             gi.Kernel,
-		WiretrusteeVersion: "",
+		WiretrusteeVersion: gi.WiretrusteeVersion,
 	}
 	log.Debugf("detected system %v", meta)
 	return c.login(serverKey, &proto.LoginRequest{SetupKey: setupKey, Meta: meta})


### PR DESCRIPTION
Changes: 
   * sends the client version now to management server instead of empty string
   * moved the version information to the system package