### PR TITLE
extracted accountmanager to interface

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -10,7 +10,26 @@ import (
 	"sync"
 )
 
-type AccountManager struct {
+type AccountManager interface {
+	GetOrCreateAccountByUser(userId, domain string) (*Account, error)
+	GetAccountByUser(userId string) (*Account, error)
+	AddSetupKey(accountId string, keyName string, keyType SetupKeyType, expiresIn *util.Duration) (*SetupKey, error)
+	RevokeSetupKey(accountId string, keyId string) (*SetupKey, error)
+	RenameSetupKey(accountId string, keyId string, newName string) (*SetupKey, error)
+	GetAccountById(accountId string) (*Account, error)
+	GetAccountByUserOrAccountId(userId, accountId, domain string) (*Account, error)
+	AccountExists(accountId string) (*bool, error)
+	AddAccount(accountId, userId, domain string) (*Account, error)
+	GetPeer(peerKey string) (*Peer, error)
+	MarkPeerConnected(peerKey string, connected bool) error
+	RenamePeer(accountId string, peerKey string, newName string) (*Peer, error)
+	DeletePeer(accountId string, peerKey string) (*Peer, error)
+	GetPeerByIP(accountId string, peerIP string) (*Peer, error)
+	GetNetworkMap(peerKey string) (*NetworkMap, error)
+	AddPeer(setupKey string, peer *Peer) (*Peer, error)
+}
+
+type DefaultAccountManager struct {
 	Store Store
 	// mutex to synchronise account operations (e.g. generating Peer IP address inside the Network)
 	mux                sync.Mutex
@@ -62,9 +81,9 @@ func (a *Account) Copy() *Account {
 	}
 }
 
-// NewManager creates a new AccountManager with a provided Store
-func NewManager(store Store, peersUpdateManager *PeersUpdateManager, idpManager idp.Manager) *AccountManager {
-	return &AccountManager{
+// NewManager creates a new DefaultAccountManager with a provided Store
+func NewManager(store Store, peersUpdateManager *PeersUpdateManager, idpManager idp.Manager) *DefaultAccountManager {
+	return &DefaultAccountManager{
 		Store:              store,
 		mux:                sync.Mutex{},
 		peersUpdateManager: peersUpdateManager,
@@ -73,7 +92,7 @@ func NewManager(store Store, peersUpdateManager *PeersUpdateManager, idpManager 
 }
 
 //AddSetupKey generates a new setup key with a given name and type, and adds it to the specified account
-func (am *AccountManager) AddSetupKey(accountId string, keyName string, keyType SetupKeyType, expiresIn *util.Duration) (*SetupKey, error) {
+func (am *DefaultAccountManager) AddSetupKey(accountId string, keyName string, keyType SetupKeyType, expiresIn *util.Duration) (*SetupKey, error) {
 	am.mux.Lock()
 	defer am.mux.Unlock()
 
@@ -99,7 +118,7 @@ func (am *AccountManager) AddSetupKey(accountId string, keyName string, keyType 
 }
 
 //RevokeSetupKey marks SetupKey as revoked - becomes not valid anymore
-func (am *AccountManager) RevokeSetupKey(accountId string, keyId string) (*SetupKey, error) {
+func (am *DefaultAccountManager) RevokeSetupKey(accountId string, keyId string) (*SetupKey, error) {
 	am.mux.Lock()
 	defer am.mux.Unlock()
 
@@ -125,7 +144,7 @@ func (am *AccountManager) RevokeSetupKey(accountId string, keyId string) (*Setup
 }
 
 //RenameSetupKey renames existing setup key of the specified account.
-func (am *AccountManager) RenameSetupKey(accountId string, keyId string, newName string) (*SetupKey, error) {
+func (am *DefaultAccountManager) RenameSetupKey(accountId string, keyId string, newName string) (*SetupKey, error) {
 	am.mux.Lock()
 	defer am.mux.Unlock()
 
@@ -151,7 +170,7 @@ func (am *AccountManager) RenameSetupKey(accountId string, keyId string, newName
 }
 
 //GetAccountById returns an existing account using its ID or error (NotFound) if doesn't exist
-func (am *AccountManager) GetAccountById(accountId string) (*Account, error) {
+func (am *DefaultAccountManager) GetAccountById(accountId string) (*Account, error) {
 	am.mux.Lock()
 	defer am.mux.Unlock()
 
@@ -165,7 +184,7 @@ func (am *AccountManager) GetAccountById(accountId string) (*Account, error) {
 
 //GetAccountByUserOrAccountId look for an account by user or account Id, if no account is provided and
 // user id doesn't have an account associated with it, one account is created
-func (am *AccountManager) GetAccountByUserOrAccountId(userId, accountId, domain string) (*Account, error) {
+func (am *DefaultAccountManager) GetAccountByUserOrAccountId(userId, accountId, domain string) (*Account, error) {
 
 	if accountId != "" {
 		return am.GetAccountById(accountId)
@@ -188,7 +207,7 @@ func (am *AccountManager) GetAccountByUserOrAccountId(userId, accountId, domain 
 }
 
 //AccountExists checks whether account exists (returns true) or not (returns false)
-func (am *AccountManager) AccountExists(accountId string) (*bool, error) {
+func (am *DefaultAccountManager) AccountExists(accountId string) (*bool, error) {
 	am.mux.Lock()
 	defer am.mux.Unlock()
 
@@ -208,7 +227,7 @@ func (am *AccountManager) AccountExists(accountId string) (*bool, error) {
 }
 
 // AddAccount generates a new Account with a provided accountId and userId, saves to the Store
-func (am *AccountManager) AddAccount(accountId, userId, domain string) (*Account, error) {
+func (am *DefaultAccountManager) AddAccount(accountId, userId, domain string) (*Account, error) {
 
 	am.mux.Lock()
 	defer am.mux.Unlock()
@@ -217,7 +236,7 @@ func (am *AccountManager) AddAccount(accountId, userId, domain string) (*Account
 
 }
 
-func (am *AccountManager) createAccount(accountId, userId, domain string) (*Account, error) {
+func (am *DefaultAccountManager) createAccount(accountId, userId, domain string) (*Account, error) {
 	account := newAccountWithId(accountId, userId, domain)
 
 	err := am.Store.SaveAccount(account)

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -320,7 +320,7 @@ func TestAccountManager_DeletePeer(t *testing.T) {
 
 }
 
-func createManager(t *testing.T) (*AccountManager, error) {
+func createManager(t *testing.T) (*DefaultAccountManager, error) {
 	store, err := createStore(t)
 	if err != nil {
 		return nil, err

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -16,7 +16,7 @@ import (
 
 // Server an instance of a Management server
 type Server struct {
-	accountManager *AccountManager
+	accountManager *DefaultAccountManager
 	wgKey          wgtypes.Key
 	proto.UnimplementedManagementServiceServer
 	peersUpdateManager     *PeersUpdateManager
@@ -28,7 +28,7 @@ type Server struct {
 const AllowedIPsFormat = "%s/32"
 
 // NewServer creates a new Management server
-func NewServer(config *Config, accountManager *AccountManager, peersUpdateManager *PeersUpdateManager, turnCredentialsManager TURNCredentialsManager) (*Server, error) {
+func NewServer(config *Config, accountManager *DefaultAccountManager, peersUpdateManager *PeersUpdateManager, turnCredentialsManager TURNCredentialsManager) (*Server, error) {
 	key, err := wgtypes.GeneratePrivateKey()
 	if err != nil {
 		return nil, err
@@ -158,7 +158,7 @@ func (s *Server) registerPeer(peerKey wgtypes.Key, req *proto.LoginRequest) (*Pe
 		return nil, status.Errorf(codes.NotFound, "provided setup key doesn't exists")
 	}
 
-	//todo move to AccountManager the code below
+	//todo move to DefaultAccountManager the code below
 	networkMap, err := s.accountManager.GetNetworkMap(peer.Key)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "internal server error")

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -16,7 +16,7 @@ import (
 
 // Server an instance of a Management server
 type Server struct {
-	accountManager *DefaultAccountManager
+	accountManager *AccountManager
 	wgKey          wgtypes.Key
 	proto.UnimplementedManagementServiceServer
 	peersUpdateManager     *PeersUpdateManager
@@ -28,7 +28,7 @@ type Server struct {
 const AllowedIPsFormat = "%s/32"
 
 // NewServer creates a new Management server
-func NewServer(config *Config, accountManager *DefaultAccountManager, peersUpdateManager *PeersUpdateManager, turnCredentialsManager TURNCredentialsManager) (*Server, error) {
+func NewServer(config *Config, accountManager *AccountManager, peersUpdateManager *PeersUpdateManager, turnCredentialsManager TURNCredentialsManager) (*Server, error) {
 	key, err := wgtypes.GeneratePrivateKey()
 	if err != nil {
 		return nil, err

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -16,7 +16,7 @@ import (
 
 // Server an instance of a Management server
 type Server struct {
-	accountManager *AccountManager
+	accountManager AccountManager
 	wgKey          wgtypes.Key
 	proto.UnimplementedManagementServiceServer
 	peersUpdateManager     *PeersUpdateManager
@@ -28,7 +28,7 @@ type Server struct {
 const AllowedIPsFormat = "%s/32"
 
 // NewServer creates a new Management server
-func NewServer(config *Config, accountManager *AccountManager, peersUpdateManager *PeersUpdateManager, turnCredentialsManager TURNCredentialsManager) (*Server, error) {
+func NewServer(config *Config, accountManager AccountManager, peersUpdateManager *PeersUpdateManager, turnCredentialsManager TURNCredentialsManager) (*Server, error) {
 	key, err := wgtypes.GeneratePrivateKey()
 	if err != nil {
 		return nil, err

--- a/management/server/http/handler/peers.go
+++ b/management/server/http/handler/peers.go
@@ -3,16 +3,17 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 	"github.com/wiretrustee/wiretrustee/management/server"
-	"net/http"
-	"time"
 )
 
 //Peers is a handler that returns peers of the account
 type Peers struct {
-	accountManager *server.DefaultAccountManager
+	accountManager server.AccountManager
 	authAudience   string
 }
 

--- a/management/server/http/handler/peers.go
+++ b/management/server/http/handler/peers.go
@@ -32,7 +32,7 @@ type PeerRequest struct {
 	Name string
 }
 
-func NewPeers(accountManager *server.DefaultAccountManager, authAudience string) *Peers {
+func NewPeers(accountManager server.AccountManager, authAudience string) *Peers {
 	return &Peers{
 		accountManager: accountManager,
 		authAudience:   authAudience,

--- a/management/server/http/handler/peers.go
+++ b/management/server/http/handler/peers.go
@@ -12,7 +12,7 @@ import (
 
 //Peers is a handler that returns peers of the account
 type Peers struct {
-	accountManager *server.AccountManager
+	accountManager *server.DefaultAccountManager
 	authAudience   string
 }
 
@@ -31,7 +31,7 @@ type PeerRequest struct {
 	Name string
 }
 
-func NewPeers(accountManager *server.AccountManager, authAudience string) *Peers {
+func NewPeers(accountManager *server.DefaultAccountManager, authAudience string) *Peers {
 	return &Peers{
 		accountManager: accountManager,
 		authAudience:   authAudience,

--- a/management/server/http/handler/setupkeys.go
+++ b/management/server/http/handler/setupkeys.go
@@ -3,19 +3,20 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 	"github.com/wiretrustee/wiretrustee/management/server"
 	"github.com/wiretrustee/wiretrustee/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"net/http"
-	"time"
 )
 
 // SetupKeys is a handler that returns a list of setup keys of the account
 type SetupKeys struct {
-	accountManager *server.DefaultAccountManager
+	accountManager server.AccountManager
 	authAudience   string
 }
 
@@ -41,7 +42,7 @@ type SetupKeyRequest struct {
 	Revoked   bool
 }
 
-func NewSetupKeysHandler(accountManager *server.DefaultAccountManager, authAudience string) *SetupKeys {
+func NewSetupKeysHandler(accountManager server.AccountManager, authAudience string) *SetupKeys {
 	return &SetupKeys{
 		accountManager: accountManager,
 		authAudience:   authAudience,

--- a/management/server/http/handler/setupkeys.go
+++ b/management/server/http/handler/setupkeys.go
@@ -15,7 +15,7 @@ import (
 
 // SetupKeys is a handler that returns a list of setup keys of the account
 type SetupKeys struct {
-	accountManager *server.AccountManager
+	accountManager *server.DefaultAccountManager
 	authAudience   string
 }
 
@@ -41,7 +41,7 @@ type SetupKeyRequest struct {
 	Revoked   bool
 }
 
-func NewSetupKeysHandler(accountManager *server.AccountManager, authAudience string) *SetupKeys {
+func NewSetupKeysHandler(accountManager *server.DefaultAccountManager, authAudience string) *SetupKeys {
 	return &SetupKeys{
 		accountManager: accountManager,
 		authAudience:   authAudience,

--- a/management/server/http/server.go
+++ b/management/server/http/server.go
@@ -20,12 +20,12 @@ type Server struct {
 	config         *s.HttpServerConfig
 	certManager    *autocert.Manager
 	tlsConfig      *tls.Config
-	accountManager *s.AccountManager
+	accountManager s.AccountManager
 }
 
 // NewHttpsServer creates a new HTTPs server (with HTTPS support) and a certManager that is responsible for generating and renewing Let's Encrypt certificate
 // The listening address will be :443 no matter what was specified in s.HttpServerConfig.Address
-func NewHttpsServer(config *s.HttpServerConfig, certManager *autocert.Manager, accountManager *s.AccountManager) *Server {
+func NewHttpsServer(config *s.HttpServerConfig, certManager *autocert.Manager, accountManager s.AccountManager) *Server {
 	server := &http.Server{
 		Addr:         config.Address,
 		WriteTimeout: time.Second * 15,
@@ -37,7 +37,7 @@ func NewHttpsServer(config *s.HttpServerConfig, certManager *autocert.Manager, a
 
 // NewHttpsServerWithTLSConfig creates a new HTTPs server with a provided tls.Config.
 // Usually used when you already have a certificate
-func NewHttpsServerWithTLSConfig(config *s.HttpServerConfig, tlsConfig *tls.Config, accountManager *s.AccountManager) *Server {
+func NewHttpsServerWithTLSConfig(config *s.HttpServerConfig, tlsConfig *tls.Config, accountManager s.AccountManager) *Server {
 	server := &http.Server{
 		Addr:         config.Address,
 		WriteTimeout: time.Second * 15,
@@ -48,7 +48,7 @@ func NewHttpsServerWithTLSConfig(config *s.HttpServerConfig, tlsConfig *tls.Conf
 }
 
 // NewHttpServer creates a new HTTP server (without HTTPS)
-func NewHttpServer(config *s.HttpServerConfig, accountManager *s.AccountManager) *Server {
+func NewHttpServer(config *s.HttpServerConfig, accountManager s.AccountManager) *Server {
 	return NewHttpsServer(config, nil, accountManager)
 }
 

--- a/management/server/http/server.go
+++ b/management/server/http/server.go
@@ -19,12 +19,12 @@ type Server struct {
 	config         *s.HttpServerConfig
 	certManager    *autocert.Manager
 	tlsConfig      *tls.Config
-	accountManager *s.AccountManager
+	accountManager *s.DefaultAccountManager
 }
 
 // NewHttpsServer creates a new HTTPs server (with HTTPS support) and a certManager that is responsible for generating and renewing Let's Encrypt certificate
 // The listening address will be :443 no matter what was specified in s.HttpServerConfig.Address
-func NewHttpsServer(config *s.HttpServerConfig, certManager *autocert.Manager, accountManager *s.AccountManager) *Server {
+func NewHttpsServer(config *s.HttpServerConfig, certManager *autocert.Manager, accountManager *s.DefaultAccountManager) *Server {
 	server := &http.Server{
 		Addr:         config.Address,
 		WriteTimeout: time.Second * 15,
@@ -36,7 +36,7 @@ func NewHttpsServer(config *s.HttpServerConfig, certManager *autocert.Manager, a
 
 // NewHttpsServerWithTLSConfig creates a new HTTPs server with a provided tls.Config.
 // Usually used when you already have a certificate
-func NewHttpsServerWithTLSConfig(config *s.HttpServerConfig, tlsConfig *tls.Config, accountManager *s.AccountManager) *Server {
+func NewHttpsServerWithTLSConfig(config *s.HttpServerConfig, tlsConfig *tls.Config, accountManager *s.DefaultAccountManager) *Server {
 	server := &http.Server{
 		Addr:         config.Address,
 		WriteTimeout: time.Second * 15,
@@ -47,7 +47,7 @@ func NewHttpsServerWithTLSConfig(config *s.HttpServerConfig, tlsConfig *tls.Conf
 }
 
 // NewHttpServer creates a new HTTP server (without HTTPS)
-func NewHttpServer(config *s.HttpServerConfig, accountManager *s.AccountManager) *Server {
+func NewHttpServer(config *s.HttpServerConfig, accountManager *s.DefaultAccountManager) *Server {
 	return NewHttpsServer(config, nil, accountManager)
 }
 

--- a/management/server/http/server.go
+++ b/management/server/http/server.go
@@ -3,6 +3,9 @@ package http
 import (
 	"context"
 	"crypto/tls"
+	"net/http"
+	"time"
+
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
 	log "github.com/sirupsen/logrus"
@@ -10,8 +13,6 @@ import (
 	"github.com/wiretrustee/wiretrustee/management/server/http/handler"
 	"github.com/wiretrustee/wiretrustee/management/server/http/middleware"
 	"golang.org/x/crypto/acme/autocert"
-	"net/http"
-	"time"
 )
 
 type Server struct {
@@ -19,12 +20,12 @@ type Server struct {
 	config         *s.HttpServerConfig
 	certManager    *autocert.Manager
 	tlsConfig      *tls.Config
-	accountManager *s.DefaultAccountManager
+	accountManager *s.AccountManager
 }
 
 // NewHttpsServer creates a new HTTPs server (with HTTPS support) and a certManager that is responsible for generating and renewing Let's Encrypt certificate
 // The listening address will be :443 no matter what was specified in s.HttpServerConfig.Address
-func NewHttpsServer(config *s.HttpServerConfig, certManager *autocert.Manager, accountManager *s.DefaultAccountManager) *Server {
+func NewHttpsServer(config *s.HttpServerConfig, certManager *autocert.Manager, accountManager *s.AccountManager) *Server {
 	server := &http.Server{
 		Addr:         config.Address,
 		WriteTimeout: time.Second * 15,
@@ -36,7 +37,7 @@ func NewHttpsServer(config *s.HttpServerConfig, certManager *autocert.Manager, a
 
 // NewHttpsServerWithTLSConfig creates a new HTTPs server with a provided tls.Config.
 // Usually used when you already have a certificate
-func NewHttpsServerWithTLSConfig(config *s.HttpServerConfig, tlsConfig *tls.Config, accountManager *s.DefaultAccountManager) *Server {
+func NewHttpsServerWithTLSConfig(config *s.HttpServerConfig, tlsConfig *tls.Config, accountManager *s.AccountManager) *Server {
 	server := &http.Server{
 		Addr:         config.Address,
 		WriteTimeout: time.Second * 15,
@@ -47,7 +48,7 @@ func NewHttpsServerWithTLSConfig(config *s.HttpServerConfig, tlsConfig *tls.Conf
 }
 
 // NewHttpServer creates a new HTTP server (without HTTPS)
-func NewHttpServer(config *s.HttpServerConfig, accountManager *s.DefaultAccountManager) *Server {
+func NewHttpServer(config *s.HttpServerConfig, accountManager *s.AccountManager) *Server {
 	return NewHttpsServer(config, nil, accountManager)
 }
 

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -56,7 +56,7 @@ func (p *Peer) Copy() *Peer {
 }
 
 //GetPeer returns a peer from a Store
-func (am *AccountManager) GetPeer(peerKey string) (*Peer, error) {
+func (am *DefaultAccountManager) GetPeer(peerKey string) (*Peer, error) {
 	am.mux.Lock()
 	defer am.mux.Unlock()
 
@@ -69,7 +69,7 @@ func (am *AccountManager) GetPeer(peerKey string) (*Peer, error) {
 }
 
 //MarkPeerConnected marks peer as connected (true) or disconnected (false)
-func (am *AccountManager) MarkPeerConnected(peerKey string, connected bool) error {
+func (am *DefaultAccountManager) MarkPeerConnected(peerKey string, connected bool) error {
 	am.mux.Lock()
 	defer am.mux.Unlock()
 
@@ -94,7 +94,7 @@ func (am *AccountManager) MarkPeerConnected(peerKey string, connected bool) erro
 }
 
 //RenamePeer changes peer's name
-func (am *AccountManager) RenamePeer(accountId string, peerKey string, newName string) (*Peer, error) {
+func (am *DefaultAccountManager) RenamePeer(accountId string, peerKey string, newName string) (*Peer, error) {
 	am.mux.Lock()
 	defer am.mux.Unlock()
 
@@ -114,7 +114,7 @@ func (am *AccountManager) RenamePeer(accountId string, peerKey string, newName s
 }
 
 //DeletePeer removes peer from the account by it's IP
-func (am *AccountManager) DeletePeer(accountId string, peerKey string) (*Peer, error) {
+func (am *DefaultAccountManager) DeletePeer(accountId string, peerKey string) (*Peer, error) {
 	am.mux.Lock()
 	defer am.mux.Unlock()
 
@@ -188,7 +188,7 @@ func (am *AccountManager) DeletePeer(accountId string, peerKey string) (*Peer, e
 }
 
 //GetPeerByIP returns peer by it's IP
-func (am *AccountManager) GetPeerByIP(accountId string, peerIP string) (*Peer, error) {
+func (am *DefaultAccountManager) GetPeerByIP(accountId string, peerIP string) (*Peer, error) {
 	am.mux.Lock()
 	defer am.mux.Unlock()
 
@@ -207,7 +207,7 @@ func (am *AccountManager) GetPeerByIP(accountId string, peerIP string) (*Peer, e
 }
 
 // GetNetworkMap returns Network map for a given peer (omits original peer from the Peers result)
-func (am *AccountManager) GetNetworkMap(peerKey string) (*NetworkMap, error) {
+func (am *DefaultAccountManager) GetNetworkMap(peerKey string) (*NetworkMap, error) {
 	am.mux.Lock()
 	defer am.mux.Unlock()
 
@@ -235,7 +235,7 @@ func (am *AccountManager) GetNetworkMap(peerKey string) (*NetworkMap, error) {
 // will be returned, meaning the key is invalid
 // Each new Peer will be assigned a new next net.IP from the Account.Network and Account.Network.LastIP will be updated (IP's are not reused).
 // The peer property is just a placeholder for the Peer properties to pass further
-func (am *AccountManager) AddPeer(setupKey string, peer *Peer) (*Peer, error) {
+func (am *DefaultAccountManager) AddPeer(setupKey string, peer *Peer) (*Peer, error) {
 	am.mux.Lock()
 	defer am.mux.Unlock()
 

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -40,7 +40,7 @@ func NewAdminUser(id string) *User {
 }
 
 // GetOrCreateAccountByUser returns an existing account for a given user id or creates a new one if doesn't exist
-func (am *AccountManager) GetOrCreateAccountByUser(userId, domain string) (*Account, error) {
+func (am *DefaultAccountManager) GetOrCreateAccountByUser(userId, domain string) (*Account, error) {
 	am.mux.Lock()
 	defer am.mux.Unlock()
 
@@ -71,7 +71,7 @@ func (am *AccountManager) GetOrCreateAccountByUser(userId, domain string) (*Acco
 }
 
 // GetAccountByUser returns an existing account for a given user id, NotFound if account couldn't be found
-func (am *AccountManager) GetAccountByUser(userId string) (*Account, error) {
+func (am *DefaultAccountManager) GetAccountByUser(userId string) (*Account, error) {
 	am.mux.Lock()
 	defer am.mux.Unlock()
 


### PR DESCRIPTION
Accountmanager has been extracted to an interface, and the previous implementation renamed to DefaultAccountManager