### PR TITLE
Write to temp file before saving data

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -433,8 +433,6 @@ github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJ
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/wiretrustee/ice/v2 v2.1.21-0.20220216144753-138db20d36ad h1:S61dy7FWFITWs/WHk2JJvJd600rWyT8Qsm9ct9nUpOQ=
-github.com/wiretrustee/ice/v2 v2.1.21-0.20220216144753-138db20d36ad/go.mod h1:XT1Nrb4OxbVFPffbQMbq4PaeEkpRLVzdphh3fjrw7DY=
 github.com/wiretrustee/ice/v2 v2.1.21-0.20220218121004-dc81faead4bb h1:CU1/+CEeCPvYXgfAyqTJXSQSf6hW3wsWM6Dfz6HkHEQ=
 github.com/wiretrustee/ice/v2 v2.1.21-0.20220218121004-dc81faead4bb/go.mod h1:XT1Nrb4OxbVFPffbQMbq4PaeEkpRLVzdphh3fjrw7DY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/util/file.go
+++ b/util/file.go
@@ -29,19 +29,26 @@ func WriteJson(file string, obj interface{}) error {
 		return err
 	}
 
-	defer func() {
-		_, err = os.Stat(tempFile.Name())
-		if err == nil {
-			os.Remove(tempFile.Name())
-		}
-	}()
-
-	err = ioutil.WriteFile(tempFile.Name(), bs, 0600)
+	tempFileName := tempFile.Name()
+	// closing file ops as windows doesn't allow to move it
+	err = tempFile.Close()
 	if err != nil {
 		return err
 	}
 
-	err = os.Rename(tempFile.Name(), file)
+	defer func() {
+		_, err = os.Stat(tempFileName)
+		if err == nil {
+			os.Remove(tempFileName)
+		}
+	}()
+
+	err = ioutil.WriteFile(tempFileName, bs, 0600)
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(tempFileName, file)
 	if err != nil {
 		return err
 	}

--- a/util/file.go
+++ b/util/file.go
@@ -12,7 +12,7 @@ import (
 // The output JSON is pretty-formatted
 func WriteJson(file string, obj interface{}) error {
 
-	configDir := filepath.Dir(file)
+	configDir, configFileName := filepath.Split(file)
 	err := os.MkdirAll(configDir, 0750)
 	if err != nil {
 		return err
@@ -24,7 +24,24 @@ func WriteJson(file string, obj interface{}) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(file, bs, 0600)
+	tempFile, err := ioutil.TempFile(configDir, ".*"+configFileName)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_, err = os.Stat(tempFile.Name())
+		if err == nil {
+			os.Remove(tempFile.Name())
+		}
+	}()
+
+	err = ioutil.WriteFile(tempFile.Name(), bs, 0600)
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(tempFile.Name(), file)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In the event of a full disk, we may encounter the case where the destination file gets replaced by an empty file as the ioutil.WriteFile truncates the destination before writing.

Closes #237 