### PR TITLE
Remove Wireguard peer in no-proxy mode on Close

### DIFF
--- a/client/internal/proxy/noproxy.go
+++ b/client/internal/proxy/noproxy.go
@@ -21,7 +21,10 @@ func NewNoProxy(config Config) *NoProxy {
 }
 
 func (p *NoProxy) Close() error {
-	// noop
+	err := p.config.WgInterface.RemovePeer(p.config.RemoteKey)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
When connection is closed the wireguard peer should be gone.
It wasn't happening until this fix.