### PR TITLE
Fix IDP Manager config structs with correct tags

### DIFF
--- a/management/server/idp/auth0.go
+++ b/management/server/idp/auth0.go
@@ -97,6 +97,8 @@ func (c *Auth0Credentials) requestJWTToken() (*http.Response, error) {
 
 	req.Header.Add("content-type", "application/json")
 
+	log.Debug("requesting new jwt token for idp manager")
+
 	res, err = c.httpClient.Do(req)
 	if err != nil {
 		return res, err
@@ -194,6 +196,8 @@ func (am *Auth0Manager) UpdateUserAppMetadata(userId string, appMetadata AppMeta
 	}
 	req.Header.Add("authorization", "Bearer "+jwtToken.AccessToken)
 	req.Header.Add("content-type", "application/json")
+
+	log.Debugf("updating metadata for user %s", userId)
 
 	res, err := am.httpClient.Do(req)
 	if err != nil {

--- a/management/server/idp/auth0.go
+++ b/management/server/idp/auth0.go
@@ -23,7 +23,16 @@ type Auth0Manager struct {
 
 // Auth0ClientConfig auth0 manager client configurations
 type Auth0ClientConfig struct {
-	Audience     string `json:"audiance"`
+	Audience     string
+	AuthIssuer   string
+	ClientId     string
+	ClientSecret string
+	GrantType    string
+}
+
+// auth0JWTRequest payload struct to request a JWT Token
+type auth0JWTRequest struct {
+	Audience     string `json:"audience"`
 	AuthIssuer   string `json:"auth_issuer"`
 	ClientId     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
@@ -44,7 +53,6 @@ func NewAuth0Manager(config Auth0ClientConfig) *Auth0Manager {
 
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
 	httpTransport.MaxIdleConns = 5
-	httpTransport.IdleConnTimeout = 30
 
 	httpClient := &http.Client{
 		Timeout:   10 * time.Second,
@@ -76,7 +84,7 @@ func (c *Auth0Credentials) requestJWTToken() (*http.Response, error) {
 	var res *http.Response
 	url := c.clientConfig.AuthIssuer + "/oauth/token"
 
-	p, err := c.helper.Marshal(c.clientConfig)
+	p, err := c.helper.Marshal(auth0JWTRequest(c.clientConfig))
 	if err != nil {
 		return res, err
 	}

--- a/management/server/idp/auth0.go
+++ b/management/server/idp/auth0.go
@@ -49,7 +49,7 @@ type Auth0Credentials struct {
 }
 
 // NewAuth0Manager creates a new instance of the Auth0Manager
-func NewAuth0Manager(config Auth0ClientConfig) *Auth0Manager {
+func NewAuth0Manager(config Auth0ClientConfig) (*Auth0Manager, error) {
 
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
 	httpTransport.MaxIdleConns = 5
@@ -61,6 +61,18 @@ func NewAuth0Manager(config Auth0ClientConfig) *Auth0Manager {
 
 	helper := JsonParser{}
 
+	if config.ClientId == "" || config.ClientSecret == "" || config.GrantType == "" || config.Audience == "" || config.AuthIssuer == "" {
+		return nil, fmt.Errorf("auth0 idp configuration is not complete")
+	}
+
+	if config.GrantType != "client_credentials" {
+		return nil, fmt.Errorf("auth0 idp configuration failed. Grant Type should be client_credentials")
+	}
+
+	if !strings.HasPrefix(strings.ToLower(config.AuthIssuer), "https://") {
+		return nil, fmt.Errorf("auth0 idp configuration failed. AuthIssuer should contain https://")
+	}
+
 	credentials := &Auth0Credentials{
 		clientConfig: config,
 		httpClient:   httpClient,
@@ -71,7 +83,7 @@ func NewAuth0Manager(config Auth0ClientConfig) *Auth0Manager {
 		credentials: credentials,
 		httpClient:  httpClient,
 		helper:      helper,
-	}
+	}, nil
 }
 
 // jwtStillValid returns true if the token still valid and have enough time to be used and get a response from Auth0

--- a/management/server/idp/auth0.go
+++ b/management/server/idp/auth0.go
@@ -25,7 +25,7 @@ type Auth0Manager struct {
 type Auth0ClientConfig struct {
 	Audience     string
 	AuthIssuer   string
-	ClientId     string
+	ClientID     string
 	ClientSecret string
 	GrantType    string
 }
@@ -34,7 +34,7 @@ type Auth0ClientConfig struct {
 type auth0JWTRequest struct {
 	Audience     string `json:"audience"`
 	AuthIssuer   string `json:"auth_issuer"`
-	ClientId     string `json:"client_id"`
+	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 	GrantType    string `json:"grant_type"`
 }
@@ -61,7 +61,7 @@ func NewAuth0Manager(config Auth0ClientConfig) (*Auth0Manager, error) {
 
 	helper := JsonParser{}
 
-	if config.ClientId == "" || config.ClientSecret == "" || config.GrantType == "" || config.Audience == "" || config.AuthIssuer == "" {
+	if config.ClientID == "" || config.ClientSecret == "" || config.GrantType == "" || config.Audience == "" || config.AuthIssuer == "" {
 		return nil, fmt.Errorf("auth0 idp configuration is not complete")
 	}
 

--- a/management/server/idp/auth0_test.go
+++ b/management/server/idp/auth0_test.go
@@ -415,7 +415,7 @@ func TestNewAuth0Manager(t *testing.T) {
 	defaultTestConfig := Auth0ClientConfig{
 		AuthIssuer:   "https://abc-auth0.eu.auth0.com",
 		Audience:     "https://abc-auth0.eu.auth0.com/api/v2/",
-		ClientId:     "abcdefg",
+		ClientID:     "abcdefg",
 		ClientSecret: "supersecret",
 		GrantType:    "client_credentials",
 	}
@@ -428,7 +428,7 @@ func TestNewAuth0Manager(t *testing.T) {
 	}
 
 	testCase2Config := defaultTestConfig
-	testCase2Config.ClientId = ""
+	testCase2Config.ClientID = ""
 
 	testCase2 := test{
 		name:                 "Missing Configuration",

--- a/management/server/idp/idp.go
+++ b/management/server/idp/idp.go
@@ -56,7 +56,7 @@ func NewManager(config Config) (Manager, error) {
 	case "none", "":
 		return nil, nil
 	case "auth0":
-		return NewAuth0Manager(config.Auth0ClientCredentials), nil
+		return NewAuth0Manager(config.Auth0ClientCredentials)
 	default:
 		return nil, fmt.Errorf("invalid manager type: %s", config.ManagerType)
 	}

--- a/management/server/testdata/management.json
+++ b/management/server/testdata/management.json
@@ -35,10 +35,10 @@
         "AuthKeysLocation": "<PASTE YOUR AUTH0 PUBLIC JWT KEYS LOCATION HERE>"
     },
     "IdpManagerConfig": {
-        "Manager": "<none|auth0>",
+        "ManagerType": "<none|auth0>",
         "Auth0ClientCredentials": {
             "Audience": "<PASTE YOUR AUTH0 AUDIENCE HERE>",
-            "AuthIssuer": "<PASTE YOUR AUTH0 Auth Issuer HERE>",
+            "AuthIssuer": "https://<PASTE YOUR AUTH0 Auth Issuer HERE>",
             "ClientId": "<PASTE YOUR AUTH0 Application Client ID HERE>",
             "ClientSecret": "<PASTE YOUR AUTH0 Application Client Secret HERE>",
             "GrantType": "client_credentials"

--- a/management/server/testdata/management.json
+++ b/management/server/testdata/management.json
@@ -39,7 +39,7 @@
         "Auth0ClientCredentials": {
             "Audience": "<PASTE YOUR AUTH0 AUDIENCE HERE>",
             "AuthIssuer": "https://<PASTE YOUR AUTH0 Auth Issuer HERE>",
-            "ClientId": "<PASTE YOUR AUTH0 Application Client ID HERE>",
+            "ClientID": "<PASTE YOUR AUTH0 Application Client ID HERE>",
             "ClientSecret": "<PASTE YOUR AUTH0 Application Client Secret HERE>",
             "GrantType": "client_credentials"
         }


### PR DESCRIPTION
When loading the configuration from file we will use the Auth0ClientConfig and when sending the post to retrieve a token
 we use the auth0JWTRequest with proper tags.

 Also, removed the idle timeout as it was closing all idle connections