### PR TITLE
Call start services function for tests

### DIFF
--- a/client/cmd/login_test.go
+++ b/client/cmd/login_test.go
@@ -2,35 +2,35 @@ package cmd
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/wiretrustee/wiretrustee/client/internal"
 	"github.com/wiretrustee/wiretrustee/iface"
-	mgmt "github.com/wiretrustee/wiretrustee/management/server"
 	"github.com/wiretrustee/wiretrustee/util"
 )
 
-var mgmAddr string
-
-func TestLogin_Start(t *testing.T) {
-	config := &mgmt.Config{}
-	_, err := util.ReadJson("../testdata/management.json", config)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testDir := t.TempDir()
-	config.Datadir = testDir
-	err = util.CopyFileContents("../testdata/store.json", filepath.Join(testDir, "store.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, listener := startManagement(t, config)
-	mgmAddr = listener.Addr().String()
-}
+//var mgmAddr string
+//
+//func TestLogin_Start(t *testing.T) {
+//	config := &mgmt.Config{}
+//	_, err := util.ReadJson("../testdata/management.json", config)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	testDir := t.TempDir()
+//	config.Datadir = testDir
+//	err = util.CopyFileContents("../testdata/store.json", filepath.Join(testDir, "store.json"))
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	_, listener := startManagement(t, config)
+//	mgmAddr = listener.Addr().String()
+//}
 
 func TestLogin(t *testing.T) {
+	mgmAddr := startTestingServices(t)
+
 	tempDir := t.TempDir()
 	confPath := tempDir + "/config.json"
 	mgmtURL := fmt.Sprintf("http://%s", mgmAddr)

--- a/client/cmd/login_test.go
+++ b/client/cmd/login_test.go
@@ -10,24 +10,6 @@ import (
 	"github.com/wiretrustee/wiretrustee/util"
 )
 
-//var mgmAddr string
-//
-//func TestLogin_Start(t *testing.T) {
-//	config := &mgmt.Config{}
-//	_, err := util.ReadJson("../testdata/management.json", config)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//	testDir := t.TempDir()
-//	config.Datadir = testDir
-//	err = util.CopyFileContents("../testdata/store.json", filepath.Join(testDir, "store.json"))
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//	_, listener := startManagement(t, config)
-//	mgmAddr = listener.Addr().String()
-//}
-
 func TestLogin(t *testing.T) {
 	mgmAddr := startTestingServices(t)
 

--- a/client/cmd/testutil.go
+++ b/client/cmd/testutil.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"github.com/wiretrustee/wiretrustee/util"
 	"net"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -14,6 +16,28 @@ import (
 	sig "github.com/wiretrustee/wiretrustee/signal/server"
 	"google.golang.org/grpc"
 )
+
+func startTestingServices(t *testing.T) string {
+	config := &mgmt.Config{}
+	_, err := util.ReadJson("../testdata/management.json", config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testDir := t.TempDir()
+	config.Datadir = testDir
+	err = util.CopyFileContents("../testdata/store.json", filepath.Join(testDir, "store.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, signalLis := startSignal(t)
+	signalAddr := signalLis.Addr().String()
+	config.Signal.URI = signalAddr
+
+	_, mgmLis := startManagement(t, config)
+	mgmAddr := mgmLis.Addr().String()
+	return mgmAddr
+}
 
 func startSignal(t *testing.T) (*grpc.Server, net.Listener) {
 	lis, err := net.Listen("tcp", ":0")
@@ -45,6 +69,7 @@ func startManagement(t *testing.T, config *mgmt.Config) (*grpc.Server, net.Liste
 	peersUpdateManager := mgmt.NewPeersUpdateManager()
 	accountManager := mgmt.NewManager(store, peersUpdateManager, nil)
 	turnManager := mgmt.NewTimeBasedAuthSecretsManager(peersUpdateManager, config.TURNConfig)
+	t.Log(config.Signal)
 	mgmtServer, err := mgmt.NewServer(config, accountManager, peersUpdateManager, turnManager)
 	if err != nil {
 		t.Fatal(err)

--- a/client/cmd/testutil.go
+++ b/client/cmd/testutil.go
@@ -69,7 +69,6 @@ func startManagement(t *testing.T, config *mgmt.Config) (*grpc.Server, net.Liste
 	peersUpdateManager := mgmt.NewPeersUpdateManager()
 	accountManager := mgmt.NewManager(store, peersUpdateManager, nil)
 	turnManager := mgmt.NewTimeBasedAuthSecretsManager(peersUpdateManager, config.TURNConfig)
-	t.Log(config.Signal)
 	mgmtServer, err := mgmt.NewServer(config, accountManager, peersUpdateManager, turnManager)
 	if err != nil {
 		t.Fatal(err)

--- a/client/cmd/up_daemon_test.go
+++ b/client/cmd/up_daemon_test.go
@@ -2,37 +2,15 @@ package cmd
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/wiretrustee/wiretrustee/client/internal"
-	mgmt "github.com/wiretrustee/wiretrustee/management/server"
-	"github.com/wiretrustee/wiretrustee/util"
 )
 
-func TestUpDaemon_Start(t *testing.T) {
-	config := &mgmt.Config{}
-	_, err := util.ReadJson("../testdata/management.json", config)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testDir := t.TempDir()
-	config.Datadir = testDir
-	err = util.CopyFileContents("../testdata/store.json", filepath.Join(testDir, "store.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, signalLis := startSignal(t)
-	signalAddr = signalLis.Addr().String()
-	config.Signal.URI = signalAddr
-
-	_, mgmLis := startManagement(t, config)
-	mgmAddr = mgmLis.Addr().String()
-}
-
 func TestUpDaemon(t *testing.T) {
+	mgmAddr := startTestingServices(t)
+
 	tempDir := t.TempDir()
 	confPath := tempDir + "/config.json"
 

--- a/client/cmd/up_test.go
+++ b/client/cmd/up_test.go
@@ -44,7 +44,7 @@ func TestUp(t *testing.T) {
 	}()
 	time.Sleep(time.Second * 2)
 
-	timeout := 15 * time.Second
+	timeout := 30 * time.Second
 	timeoutChannel := time.After(timeout)
 	for {
 		select {

--- a/client/cmd/up_test.go
+++ b/client/cmd/up_test.go
@@ -2,42 +2,20 @@ package cmd
 
 import (
 	"net/url"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/wiretrustee/wiretrustee/iface"
-	mgmt "github.com/wiretrustee/wiretrustee/management/server"
-	"github.com/wiretrustee/wiretrustee/util"
 )
 
 var (
-	signalAddr string
-	cliAddr    string
+	//signalAddr string
+	cliAddr string
 )
 
-func TestUp_Start(t *testing.T) {
-	config := &mgmt.Config{}
-	_, err := util.ReadJson("../testdata/management.json", config)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testDir := t.TempDir()
-	config.Datadir = testDir
-	err = util.CopyFileContents("../testdata/store.json", filepath.Join(testDir, "store.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, signalLis := startSignal(t)
-	signalAddr = signalLis.Addr().String()
-	config.Signal.URI = signalAddr
-
-	_, mgmLis := startManagement(t, config)
-	mgmAddr = mgmLis.Addr().String()
-}
-
 func TestUp(t *testing.T) {
+	mgmAddr := startTestingServices(t)
+
 	tempDir := t.TempDir()
 	confPath := tempDir + "/config.json"
 	mgmtURL, err := url.Parse("http://" + mgmAddr)


### PR DESCRIPTION
when testing CMDs we were using some global variables which got replaced by parallel tests.

Now we will call a single function independently for each test.