### PR TITLE
Enable Report Caller when log level Debug

### DIFF
--- a/util/log.go
+++ b/util/log.go
@@ -4,7 +4,10 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/natefinch/lumberjack.v2"
 	"io"
+	"path"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"time"
 )
 
@@ -31,6 +34,15 @@ func InitLog(logLevel string, logPath string) error {
 	logFormatter := new(log.TextFormatter)
 	logFormatter.TimestampFormat = time.RFC3339 // or RFC3339
 	logFormatter.FullTimestamp = true
+	logFormatter.CallerPrettyfier = func(frame *runtime.Frame) (function string, file string) {
+		fileName := path.Base(frame.File) + ":" + strconv.Itoa(frame.Line)
+		//return frame.Function, fileName
+		return "", fileName
+	}
+
+	if level == log.DebugLevel {
+		log.SetReportCaller(true)
+	}
 
 	log.SetFormatter(logFormatter)
 	log.SetLevel(level)


### PR DESCRIPTION
Enabling report caller when log level equals debug. Also added a Caller prettyfier to avoid full file path