### PR TITLE
Init logger for every cmd

### DIFF
--- a/client/cmd/down.go
+++ b/client/cmd/down.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"github.com/wiretrustee/wiretrustee/util"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -15,6 +16,12 @@ var downCmd = &cobra.Command{
 	Short: "down wiretrustee connections",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		SetFlagsFromEnvVars()
+
+		err := util.InitLog(logLevel, logFile)
+		if err != nil {
+			log.Errorf("failed initializing log %v", err)
+			return err
+		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
 		defer cancel()

--- a/client/cmd/login.go
+++ b/client/cmd/login.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/wiretrustee/wiretrustee/util"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -16,6 +17,13 @@ var loginCmd = &cobra.Command{
 	Short: "login to the Wiretrustee Management Service (first run)",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		SetFlagsFromEnvVars()
+
+		err := util.InitLog(logLevel, logFile)
+		if err != nil {
+			log.Errorf("failed initializing log %v", err)
+			return err
+		}
+
 		ctx := internal.CtxInitState(context.Background())
 
 		// workaround to run without service

--- a/client/cmd/status.go
+++ b/client/cmd/status.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"github.com/wiretrustee/wiretrustee/util"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -16,6 +17,13 @@ var statusCmd = &cobra.Command{
 	Short: "status of the Wiretrustee Service",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		SetFlagsFromEnvVars()
+
+		err := util.InitLog(logLevel, logFile)
+		if err != nil {
+			log.Errorf("failed initializing log %v", err)
+			return err
+		}
+
 		ctx := internal.CtxInitState(context.Background())
 
 		conn, err := DialClientGRPCServer(ctx, daemonAddr)

--- a/client/cmd/up.go
+++ b/client/cmd/up.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/wiretrustee/wiretrustee/util"
 
 	"github.com/wiretrustee/wiretrustee/client/internal"
 	"github.com/wiretrustee/wiretrustee/client/proto"
@@ -13,6 +14,13 @@ var upCmd = &cobra.Command{
 	Short: "install, login and start wiretrustee client",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		SetFlagsFromEnvVars()
+
+		err := util.InitLog(logLevel, logFile)
+		if err != nil {
+			log.Errorf("failed initializing log %v", err)
+			return err
+		}
+
 		ctx := internal.CtxInitState(cmd.Context())
 
 		// workaround to run without service


### PR DESCRIPTION
Logger has not been initialized in cmd.
Every client cmd now initializes logger