### PR TITLE
Update ManagementURL in Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,18 +199,18 @@ For **Windows** systems:
 
 ### Troubleshooting
 
-1. If you have specified a wrong `--management-url` (e.g., just by mistake when self-hosting) 
-   to override it you can do the following:
+1.  If you have specified a wrong `--management-url` (e.g., just by mistake when self-hosting)
+    to override it you can do the following:
 
-```shell
-sudo wiretrustee down
-sudo wiretrustee up --management-url https://<CORRECT HOST:PORT>/
-```
+    ```shell
+    sudo wiretrustee down
+    sudo wiretrustee up --management-url https://<CORRECT HOST:PORT>/
+    ```
 
-2. If you are using self-hosted version and haven't specified `--management-url`, the client app will use the default URL
-   which is ```https://api.wiretrustee.com:33073```. 
-   
-   To override it see solution #1 above.
+2.  If you are using self-hosted version and haven't specified `--management-url`, the client app will use the default URL
+    which is ```https://api.wiretrustee.com:33073```.
+    
+    To override it see solution #1 above.
 
 ### Running Dashboard, Management, Signal and Coturn
 See [Self-Hosting Guide](https://docs.wiretrustee.com/getting-started/self-hosting)

--- a/README.md
+++ b/README.md
@@ -197,6 +197,21 @@ For **Windows** systems:
 
 3. Repeat on other machines.  
 
+### Troubleshooting
+
+1. If you have specified a wrong `--management-url` (e.g., just by mistake when self-hosting) 
+   to override it you can do the following:
+
+```shell
+sudo wiretrustee down
+sudo wiretrustee up --management-url https://<CORRECT HOST:PORT>/
+```
+
+2. If you are using self-hosted version and haven't specified `--management-url`, the client app will use the default URL
+   which is ```https://api.wiretrustee.com:33073```. 
+   
+   To override it see solution #1 above.
+
 ### Running Dashboard, Management, Signal and Coturn
 See [Self-Hosting Guide](https://docs.wiretrustee.com/getting-started/self-hosting)
 

--- a/client/internal/config.go
+++ b/client/internal/config.go
@@ -86,12 +86,18 @@ func ReadConfig(managementURL string, configPath string) (*Config, error) {
 		return nil, err
 	}
 
-	if managementURL != "" {
+	if managementURL != "" && config.ManagementURL.String() != managementURL {
 		URL, err := parseManagementURL(managementURL)
 		if err != nil {
 			return nil, err
 		}
 		config.ManagementURL = URL
+		// since we have new management URL, we need to update config file
+		err = util.WriteJson(configPath, config)
+		if err != nil {
+			return nil, err
+		}
+		log.Infof("new Management URL provided, updated to %s (old value %s)", managementURL, config.ManagementURL)
 	}
 
 	return config, err

--- a/client/internal/config_test.go
+++ b/client/internal/config_test.go
@@ -1,0 +1,60 @@
+package internal
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/wiretrustee/wiretrustee/util"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadConfig(t *testing.T) {
+
+}
+func TestGetConfig(t *testing.T) {
+
+	managementURL := "https://test.management.url:33071"
+	path := filepath.Join(t.TempDir(), "config.json")
+	preSharedKey := "preSharedKey"
+
+	// case 1: new config has to be generated
+	config, err := GetConfig(managementURL, path, preSharedKey)
+	if err != nil {
+		return
+	}
+
+	assert.Equal(t, config.ManagementURL.String(), managementURL)
+	assert.Equal(t, config.PreSharedKey, preSharedKey)
+
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		t.Errorf("config file was expected to be created under path %s", path)
+	}
+
+	// case 2: existing config -> fetch it
+	config, err = GetConfig(managementURL, path, preSharedKey)
+	if err != nil {
+		return
+	}
+
+	assert.Equal(t, config.ManagementURL.String(), managementURL)
+	assert.Equal(t, config.PreSharedKey, preSharedKey)
+
+	// case 3: existing config, but new managementURL has been provided -> update config
+	newManagementURL := "https://test.newManagement.url:33071"
+	config, err = GetConfig(newManagementURL, path, preSharedKey)
+	if err != nil {
+		return
+	}
+
+	assert.Equal(t, config.ManagementURL.String(), newManagementURL)
+	assert.Equal(t, config.PreSharedKey, preSharedKey)
+
+	// read once more to make sure that config file has been updated with the new management URL
+	readConf, err := util.ReadJson(path, config)
+	if err != nil {
+		return
+	}
+	assert.Equal(t, readConf.(*Config).ManagementURL.String(), newManagementURL)
+
+}


### PR DESCRIPTION
If ManagementURL is present in the config file
and cmd (e.g. up or login) specifies a new one,
then update the config file with a new ManagementURL