### PR TITLE
Fix error when stopping Engine

### DIFF
--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -123,6 +123,10 @@ func (e *Engine) Stop() error {
 		return err
 	}
 
+	// very ugly but we want to remove peers from the WireGuard interface first before removing interface.
+	// Removing peers happens in the conn.CLose() asynchronously
+	time.Sleep(500 * time.Millisecond)
+
 	log.Debugf("removing Wiretrustee interface %s", e.config.WgIfaceName)
 	if e.wgInterface.Interface != nil {
 		err = e.wgInterface.Close()
@@ -489,7 +493,7 @@ func (e Engine) connWorker(conn *peer.Conn, peerKey string) {
 
 		// if peer has been removed -> give up
 		if !e.peerExists(peerKey) {
-			log.Infof("peer %s doesn't exist anymore, won't retry connection", peerKey)
+			log.Debugf("peer %s doesn't exist anymore, won't retry connection", peerKey)
 			return
 		}
 

--- a/client/internal/peer/conn.go
+++ b/client/internal/peer/conn.go
@@ -153,7 +153,7 @@ func (conn *Conn) Open() error {
 	defer func() {
 		err := conn.cleanup()
 		if err != nil {
-			log.Errorf("error while cleaning up peer connection %s: %v", conn.config.Key, err)
+			log.Warnf("error while cleaning up peer connection %s: %v", conn.config.Key, err)
 			return
 		}
 	}()


### PR DESCRIPTION
When stopping engine, all peer conns have to be closed
and for each peer WireGuard iface is called
to remove WireGuard peer.
This operation happens in a goroutine causing
Engine to remove the whole WireGuard interface before.
Therefore consequent calls to RemovePeer are unsuccessful.
This fix just adds a small delay before removing interface.