### PR TITLE
Fix goreleaser version to 1.6.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: 1.6.3
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: 1.6.3
-          bindir: /usr/bin
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: 1.6.3
+          bindir: /usr/bin
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,6 +63,7 @@ nfpms:
     description: Wiretrustee client.
     homepage: https://wiretrustee.com/
     id: deb
+    bindir: /usr/bin
     builds:
       - wiretrustee
     formats:
@@ -76,6 +77,7 @@ nfpms:
     description: Wiretrustee client.
     homepage: https://wiretrustee.com/
     id: rpm
+    bindir: /usr/bin
     builds:
       - wiretrustee
     formats:

--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ Hosted version:
 3. Decompress
   ```shell
   tar xcf ./wiretrustee_<VERSION>_darwin_amd64.tar.gz
-  sudo mv wiretrusee /usr/local/bin/wiretrustee
-  chmod +x /usr/local/bin/wiretrustee
+  sudo mv wiretrusee /usr/bin/wiretrustee
+  chmod +x /usr/bin/wiretrustee
   ```
-After that you may need to add /usr/local/bin in your PATH environment variable:
+After that you may need to add /usr/bin in your PATH environment variable:
   ````shell
-  export PATH=$PATH:/usr/local/bin
+  export PATH=$PATH:/usr/bin
   ````
 4. Install and run the service
 ```shell

--- a/client/cmd/status.go
+++ b/client/cmd/status.go
@@ -18,7 +18,7 @@ var statusCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		SetFlagsFromEnvVars()
 
-		err := util.InitLog(logLevel, logFile)
+		err := util.InitLog(logLevel, "console")
 		if err != nil {
 			log.Errorf("failed initializing log %v", err)
 			return err

--- a/release_files/post_install.sh
+++ b/release_files/post_install.sh
@@ -12,8 +12,8 @@ fi
 cleanInstall() {
     printf "\033[32m Post Install of an clean install\033[0m\n"
     # Step 3 (clean install), enable the service in the proper way for this platform
-    /usr/local/bin/wiretrustee service install
-    /usr/local/bin/wiretrustee service start
+    /usr/bin/wiretrustee service install
+    /usr/bin/wiretrustee service start
 }
 
 upgrade() {
@@ -27,9 +27,9 @@ upgrade() {
       systemctl daemon-reload
     fi
     # will trow an error until everyone upgrade
-    /usr/local/bin/wiretrustee service uninstall 2> /dev/null || true
-    /usr/local/bin/wiretrustee service install
-    /usr/local/bin/wiretrustee service start
+    /usr/bin/wiretrustee service uninstall 2> /dev/null || true
+    /usr/bin/wiretrustee service install
+    /usr/bin/wiretrustee service start
 }
 
 # Check if this is a clean install or an upgrade

--- a/release_files/pre_remove.sh
+++ b/release_files/pre_remove.sh
@@ -22,7 +22,7 @@ remove() {
 
   fi
   printf "\033[32m Uninstalling the service\033[0m\n"
-  /usr/local/bin/wiretrustee service uninstall || true
+  /usr/bin/wiretrustee service uninstall || true
 
 
   if [ "${use_systemctl}" = "True" ]; then


### PR DESCRIPTION
Since goreleaser v1.6.0 binaries are installed to
/usr/bin/ instead of /usr/local/bin/ .
This fix changes binaries path of wiretrustee
See for details:
https://github.com/goreleaser/goreleaser/releases/tag/v1.6.0